### PR TITLE
restore sdxl functionality

### DIFF
--- a/src/streamdiffusion/controlnet/base_controlnet_pipeline.py
+++ b/src/streamdiffusion/controlnet/base_controlnet_pipeline.py
@@ -1,4 +1,5 @@
 import torch
+import traceback
 from typing import List, Optional, Union, Dict, Any, Tuple
 from PIL import Image
 import numpy as np
@@ -262,6 +263,9 @@ class BaseControlNetPipeline:
             return controlnet
             
         except Exception as e:
+            print(f"Failed to load {self.model_type} ControlNet model '{model_id}': {e}")
+            print(f"Full stack trace for model loading failure:")
+            print(traceback.format_exc())
             raise ValueError(f"Failed to load {self.model_type} ControlNet model '{model_id}': {e}")
     
 
@@ -367,8 +371,9 @@ class BaseControlNetPipeline:
             'sample': x_t_latent,
             'timestep': timestep,
             'encoder_hidden_states': encoder_hidden_states,
-            **kwargs
+            'return_dict': False,
         }
+        base_kwargs.update(self._get_additional_controlnet_kwargs(**kwargs))
         
         down_samples_list = []
         mid_samples_list = []
@@ -405,6 +410,8 @@ class BaseControlNetPipeline:
                 mid_samples_list.append(mid_sample)
             except Exception as e:
                 print(f"ControlNetPipeline: ControlNet {i} failed: {e}")
+                print(f"ControlNetPipeline: Full stack trace for ControlNet {i}:")
+                print(traceback.format_exc())
                 continue
         
         # Early exit if no outputs


### PR DESCRIPTION
Restores SDXL + Controlnet functionality, resolving this error:

`ControlNetPipeline: Processing 1 ControlNets
ControlNetPipeline: Active ControlNet indices: [0]
ControlNetPipeline: Processing ControlNet 0 with scale 0.5
ControlNetPipeline: Calling ControlNet 0 with input shape: torch.Size([1, 3, 1024, 1024])
ControlNetPipeline: ControlNet 0 failed: ControlNetModel.forward() got an unexpected keyword argument 'text_embeds'
ControlNetPipeline: Full stack trace for ControlNet 0:
Traceback (most recent call last):
  File "C:\_dev\projects\StreamDiffusion\src\streamdiffusion\controlnet\base_controlnet_pipeline.py", line 405, in _get_controlnet_conditioning
    down_samples, mid_sample = controlnet(**controlnet_kwargs)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\_dev\conda\envs\comfyui\Lib\site-packages\torch\nn\modules\module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\_dev\conda\envs\comfyui\Lib\site-packages\torch\nn\modules\module.py", line 1762, in _call_impl        
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ControlNetModel.forward() got an unexpected keyword argument 'text_embeds'`