### PR TITLE
Ryan/fix/03 remove hybrid controlnet

### DIFF
--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1526,7 +1526,7 @@ class StreamDiffusionWrapper:
 
             # Create engine pool with same engine directory structure as UNet
             stream_cuda = cuda.Stream()
-            controlnet_pool = ControlNetEnginePool(engine_dir, stream_cuda, self.width, self.height, enable_pytorch_fallback=self.enable_pytorch_fallback)
+            controlnet_pool = ControlNetEnginePool(engine_dir, stream_cuda, self.width, self.height)
 
             # Store pool on the pipeline for later use
             controlnet_pipeline._controlnet_pool = controlnet_pool


### PR DESCRIPTION
This PR removes the HybridControlnet abstraction which added unnecessary complexity for little benefit.
Pytorch fallback is also removed from the interface. 
depends upon #47 