### PR TITLE
setup: Pin cuda-python version before v13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ _deps = [
     "accelerate",
     "fire",
     "omegaconf",
-    "cuda-python",
+    "cuda-python==12.9.0",
     "onnx>=1.15.0",
     "onnxruntime>=1.16.3",
     "protobuf>=3.20.2",


### PR DESCRIPTION
Set to the exact version we know works on the latest ai-runner image:
```
$ docker run --gpus all livepeer/ai-runner:live-app-streamdiffusion conda run -n comfystream pip freeze | grep cuda-py    (base)
cuda-python==12.9.0
```