### PR TITLE
feat: safety checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,4 +215,4 @@ configs/*.yml
 
 images/outputs/*
 images/inputs/*
-controlnet_test_sdturbo_multicontrolnet_test*
+controlnet_test_sdturbo_multicontrolnet_*

--- a/src/streamdiffusion/acceleration/tensorrt/__init__.py
+++ b/src/streamdiffusion/acceleration/tensorrt/__init__.py
@@ -1,12 +1,43 @@
 import gc
 import os
 import torch
+import torch.nn as nn
 from diffusers import AutoencoderKL, UNet2DConditionModel
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import (
     retrieve_latents,
 )
+from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from .builder import EngineBuilder
 from .models.models import BaseModel
+
+def cosine_distance(image_embeds, text_embeds):
+    normalized_image_embeds = nn.functional.normalize(image_embeds)
+    normalized_text_embeds = nn.functional.normalize(text_embeds)
+    return torch.mm(normalized_image_embeds, normalized_text_embeds.t())
+
+class StableDiffusionSafetyCheckerWrapper(StableDiffusionSafetyChecker):
+    def __init__(self, config):
+        super().__init__(config)
+    
+    @torch.no_grad()
+    def forward(self, clip_input):
+        pooled_output = self.vision_model(clip_input)[1]
+        image_embeds = self.visual_projection(pooled_output)
+
+        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds)
+        cos_dist = cosine_distance(image_embeds, self.concept_embeds)
+
+        adjustment = 0.0
+
+        special_scores = special_cos_dist - self.special_care_embeds_weights + adjustment
+        special_care = torch.any(special_scores > 0, dim=1)
+        special_adjustment = special_care * 0.01
+        special_adjustment = special_adjustment.unsqueeze(1).expand(-1, cos_dist.shape[1])
+
+        concept_scores = (cos_dist - self.concept_embeds_weights) + special_adjustment
+        has_nsfw_concepts = torch.any(concept_scores > 0, dim=1)
+
+        return has_nsfw_concepts
 
 class TorchVAEEncoder(torch.nn.Module):
     def __init__(self, vae: AutoencoderKL):
@@ -46,6 +77,25 @@ def compile_vae_decoder(
 ):
     vae = vae.to(torch.device("cuda"))
     builder = EngineBuilder(model_data, vae, device=torch.device("cuda"))
+    builder.build(
+        onnx_path,
+        onnx_opt_path,
+        engine_path,
+        opt_batch_size=opt_batch_size,
+        **engine_build_options,
+    )
+
+def compile_safety_checker(
+    safety_checker: StableDiffusionSafetyCheckerWrapper,
+    model_data: BaseModel,
+    onnx_path: str,
+    onnx_opt_path: str,
+    engine_path: str,
+    opt_batch_size: int = 1,
+    engine_build_options: dict = {},
+):
+    safety_checker = safety_checker.to(torch.device("cuda"))
+    builder = EngineBuilder(model_data, safety_checker, device=torch.device("cuda"))
     builder.build(
         onnx_path,
         onnx_opt_path,

--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -10,6 +10,7 @@ class EngineType(Enum):
     VAE_ENCODER = "vae_encoder" 
     VAE_DECODER = "vae_decoder"
     CONTROLNET = "controlnet"
+    SAFETY_CHECKER = "safety_checker"
 
 
 class EngineManager:
@@ -29,7 +30,7 @@ class EngineManager:
         
         # Import the existing compile functions from tensorrt/__init__.py
         from streamdiffusion.acceleration.tensorrt import (
-            compile_unet, compile_vae_encoder, compile_vae_decoder
+            compile_unet, compile_vae_encoder, compile_vae_decoder, compile_safety_checker
         )
         from streamdiffusion.acceleration.tensorrt.builder import compile_controlnet
         from streamdiffusion.acceleration.tensorrt.runtime_engines.unet_engine import (
@@ -66,6 +67,11 @@ class EngineManager:
                     str(path), cuda_stream, use_cuda_graph=kwargs.get('use_cuda_graph', False),
                     model_type=kwargs.get('model_type', 'sd15')
                 )
+            },
+            EngineType.SAFETY_CHECKER: {
+                'filename': 'safety_checker.engine',
+                'compile_fn': compile_safety_checker,
+                'loader': lambda path, cuda_stream, **kwargs: str(path)
             }
         }
     

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -283,6 +283,44 @@ class SafetyChecker(BaseModel):
             torch.randn(batch_size, 3, 224, 224, dtype=torch.float16, device=self.device),
         )
 
+class NSFWDetector(BaseModel):
+    def __init__(self, device, max_batch_size = 1, min_batch_size = 1):
+        super(NSFWDetector, self).__init__(
+            device=device,
+            max_batch_size=max_batch_size,
+            min_batch_size=min_batch_size,
+        )
+        self.name = "nsfw_detector"
+    
+    def get_input_names(self):
+        return ["pixel_values"]
+    
+    def get_output_names(self):
+        return ["logits"]
+    
+    def get_dynamic_axes(self):
+        return {"pixel_values": {0: "B"}}
+    
+    def get_input_profile(self, batch_size, *args, **kwargs):
+        return {
+            "pixel_values": [
+                (self.min_batch, 3, 224, 224),
+                (batch_size, 3, 224, 224),
+                (self.max_batch, 3, 224, 224),
+            ],
+        }
+    
+    def get_shape_dict(self, batch_size, *args, **kwargs):
+        return {
+            "pixel_values": (batch_size, 3, 224, 224),
+            "logits": (batch_size, 2),
+        }
+    
+    def get_sample_input(self, batch_size, *args, **kwargs):
+        return (
+            torch.randn(batch_size, 3, 224, 224, dtype=torch.float16, device=self.device),
+        )
+
 class UNet(BaseModel):
     def __init__(
         self,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -568,10 +568,10 @@ class StreamDiffusionWrapper:
         if self.use_safety_checker:
             safety_checker_input = self.feature_extractor(
                 image, return_tensors="pt"
-            ).to(self.device)
+            )
             _, has_nsfw_concept = self.safety_checker(
-                images=image_tensor.to(self.dtype),
-                clip_input=safety_checker_input.pixel_values.to(self.dtype),
+                images=image_tensor.to(self.device),
+                clip_input=safety_checker_input.pixel_values.to(self.device),
             )
             image = self.nsfw_fallback_img if has_nsfw_concept[0] else image
 
@@ -603,19 +603,17 @@ class StreamDiffusionWrapper:
             image = self.preprocess_image(image)
 
         image_tensor = self.stream(image)
+        image = self.postprocess_image(image_tensor, output_type=self.output_type)
 
         if self.use_safety_checker:
-            image_tensor = image_tensor.to(self.device)
             safety_checker_input = self.feature_extractor(
-                image_tensor, return_tensors="pt"
-            ).to(self.device)
+                image, return_tensors="pt"
+            )
             _, has_nsfw_concept = self.safety_checker(
-                images=image_tensor.to(self.dtype),
-                clip_input=safety_checker_input.pixel_values.to(self.dtype),
+                images=image_tensor.to(self.device),
+                clip_input=safety_checker_input.pixel_values.to(self.device),
             )
             image = self.nsfw_fallback_img if has_nsfw_concept[0] else image
-        
-        image = self.postprocess_image(image_tensor, output_type=self.output_type)
 
         return image
 


### PR DESCRIPTION
- Revives the safety checker feature with [Falconsai/nsfw_image_detection](https://huggingface.co/Falconsai/nsfw_image_detection) model because [CompVis/stable-diffusion-safety-checker](https://huggingface.co/CompVis/stable-diffusion-safety-checker) is not great, it is too sensitive to colors and adds a lot of flicker even on SFW frames but the Falconsai model is great and is SOTA for NSFW classification task
- Added optimizations to the safety check model inference because it was taking 20ms out of the box which isn't a viable option for our realtime use case.
- Optimizations include:
   - using torchvision's transform operations instead of huggingface processor because the processor uses a lot of PIL operations which are slow and don't run on GPU -- reduced the preprocessing time from 11ms to 0.2 ms
   - tensorrt compiled model -- reduced inference from 7ms 0.7ms
overall on avg takes 0.9ms - 1.5ms
- The model is always loaded on GPU as it just takes up about 170MB VRAM and the usage can be switched on and off using the use_safety_checker param