### PR TITLE
ryan/feat/multi-stage/12 multi channel tensorrt

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -156,7 +156,8 @@ class EngineManager:
             model_path=kwargs.get('model_path', ""),
             max_batch=batch_size,
             min_batch_size=1,
-            embedding_dim=embedding_dim
+            embedding_dim=embedding_dim,
+            conditioning_channels=kwargs.get('conditioning_channels', 3)
         )
         
         # Prepare ControlNet model for compilation
@@ -254,7 +255,8 @@ class EngineManager:
                                     cuda_stream = None,
                                     use_cuda_graph: bool = False,
                                     unet = None,
-                                    model_path: str = "") -> Any:
+                                    model_path: str = "",
+                                    conditioning_channels: int = 3) -> Any:
         """
         Get or load ControlNet engine, providing unified interface for ControlNet management.
         
@@ -283,5 +285,6 @@ class EngineManager:
             use_cuda_graph=use_cuda_graph,
             unet=unet,
             model_path=model_path,
+            conditioning_channels=conditioning_channels,
             engine_build_options=self._get_default_controlnet_build_options()
         )

--- a/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
@@ -17,6 +17,7 @@ class ControlNetTRT(BaseModel):
                  min_batch_size: int = 1,
                  embedding_dim: int = 768,
                  unet_dim: int = 4,
+                 conditioning_channels: int = 3,
                  **kwargs):
         super().__init__(
             fp16=fp16,
@@ -27,6 +28,7 @@ class ControlNetTRT(BaseModel):
             **kwargs
         )
         self.unet_dim = unet_dim
+        self.conditioning_channels = conditioning_channels
         self.name = "ControlNet"
         
     def get_input_names(self) -> List[str]:
@@ -94,9 +96,9 @@ class ControlNetTRT(BaseModel):
                 (max_batch, 77, self.embedding_dim),
             ],
             "controlnet_cond": [
-                (min_batch, 3, min_ctrl_h, min_ctrl_w),
-                (batch_size, 3, opt_ctrl_h, opt_ctrl_w),
-                (max_batch, 3, max_ctrl_h, max_ctrl_w),
+                (min_batch, self.conditioning_channels, min_ctrl_h, min_ctrl_w),
+                (batch_size, self.conditioning_channels, opt_ctrl_h, opt_ctrl_w),
+                (max_batch, self.conditioning_channels, max_ctrl_h, max_ctrl_w),
             ],
         }
         
@@ -114,7 +116,7 @@ class ControlNetTRT(BaseModel):
             torch.ones(batch_size, dtype=torch.float32, device=self.device),
             torch.randn(batch_size, 77, self.embedding_dim, 
                        dtype=dtype, device=self.device),
-            torch.randn(batch_size, 3, image_height, image_width, 
+            torch.randn(batch_size, self.conditioning_channels, image_height, image_width, 
                        dtype=dtype, device=self.device)
         )
 
@@ -219,7 +221,7 @@ class ControlNetSDXLTRT(ControlNetTRT):
             torch.ones(batch_size, dtype=torch.float32, device=self.device),  # timestep
             torch.randn(batch_size, self.text_maxlen, self.embedding_dim, 
                        dtype=dtype, device=self.device),  # encoder_hidden_states
-            torch.randn(batch_size, 3, image_height, image_width, 
+            torch.randn(batch_size, self.conditioning_channels, image_height, image_width, 
                        dtype=dtype, device=self.device),  # controlnet_cond
             torch.tensor(1.0, dtype=torch.float32, device=self.device),  # conditioning_scale
             torch.randn(batch_size, 1280, dtype=dtype, device=self.device),  # text_embeds
@@ -241,9 +243,11 @@ class ControlNetSDXLTRT(ControlNetTRT):
 
 def create_controlnet_model(model_type: str = "sd15", 
                            unet=None, model_path: str = "",
+                           conditioning_channels: int = 3,
                            **kwargs) -> ControlNetTRT:
     """Factory function to create appropriate ControlNet TensorRT model"""
     if model_type.lower() in ["sdxl"]:
-        return ControlNetSDXLTRT(unet=unet, model_path=model_path, **kwargs)
+        return ControlNetSDXLTRT(unet=unet, model_path=model_path, 
+                                conditioning_channels=conditioning_channels, **kwargs)
     else:
-        return ControlNetTRT(**kwargs) 
+        return ControlNetTRT(conditioning_channels=conditioning_channels, **kwargs) 

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1557,7 +1557,8 @@ class StreamDiffusionWrapper:
                                     cuda_stream=cuda_stream,
                                     use_cuda_graph=False,
                                     unet=None,
-                                    model_path=cfg['model_id']
+                                    model_path=cfg['model_id'],
+                                    conditioning_channels=cfg.get('conditioning_channels', 3)
                                 )
                                 try:
                                     setattr(engine, 'model_id', cfg['model_id'])


### PR DESCRIPTION
Depends upon #108 

SDXL support postponed, pending work from @varshith15 training a temporalnet controlnet for sdxl

This PR adds support for any number of channels in generated tensorrt engines.