### PR TITLE
feat: safety checker threshold

### DIFF
--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -291,6 +291,7 @@ class StreamDiffusionWrapper:
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
         self.safety_checker_threshold = safety_checker_threshold
+        self.safety_checker_streak = 0
 
     def prepare(
         self,
@@ -592,9 +593,13 @@ class StreamDiffusionWrapper:
             logits = self.safety_checker(pixel_values)
             nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
             if nsfw_prob > self.safety_checker_threshold:
-                image = self.nsfw_fallback_img
-            elif self.safety_checker_fallback_type == "previous":
-                self.nsfw_fallback_img = image
+                self.safety_checker_streak += 1
+                if self.safety_checker_streak > 3:
+                    image = self.nsfw_fallback_img
+            else:
+                self.safety_checker_streak = 0
+                if self.safety_checker_fallback_type == "previous":
+                    self.nsfw_fallback_img = image
 
         return image
 
@@ -634,9 +639,13 @@ class StreamDiffusionWrapper:
             logits = self.safety_checker(pixel_values)
             nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
             if nsfw_prob > self.safety_checker_threshold:
-                image = self.nsfw_fallback_img
-            elif self.safety_checker_fallback_type == "previous":
-                self.nsfw_fallback_img = image
+                self.safety_checker_streak += 1
+                if self.safety_checker_streak > 3:
+                    image = self.nsfw_fallback_img
+            else:
+                self.safety_checker_streak = 0
+                if self.safety_checker_fallback_type == "previous":
+                    self.nsfw_fallback_img = image
 
         return image
 

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -111,6 +111,7 @@ class StreamDiffusionWrapper:
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
         safety_checker_model_id: Optional[str] = "Falconsai/nsfw_image_detection",
         safety_checker_fallback_type: Literal["blank", "previous"] = "previous",
+        safety_checker_threshold: float = 0.95,
     ):
         """
         Initializes the StreamDiffusionWrapper.
@@ -193,6 +194,10 @@ class StreamDiffusionWrapper:
             Whether to enable PyTorch fallback when acceleration fails, by default False.
             When True, falls back to PyTorch inference if TensorRT/xformers acceleration fails.
             When False, raises an exception when acceleration fails.
+        safety_checker_fallback_type : Literal["blank", "previous"], optional
+            Whether to use a blank image or the previous image as a fallback, by default "previous".
+        safety_checker_threshold : float, optional
+            The threshold for the safety checker, by default 0.95.
         """
         self.sd_turbo = "turbo" in model_id_or_path
         self.use_controlnet = use_controlnet
@@ -285,6 +290,7 @@ class StreamDiffusionWrapper:
         ])
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
+        self.safety_checker_threshold = safety_checker_threshold
 
     def prepare(
         self,
@@ -583,8 +589,9 @@ class StreamDiffusionWrapper:
             else:
                 denormalized_image_tensor = image
             pixel_values = self.safety_image_transforms(denormalized_image_tensor)
-            predicted_label = self.safety_checker(pixel_values).argmax(-1).item()
-            if predicted_label == 1:
+            logits = self.safety_checker(pixel_values)
+            nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
+            if nsfw_prob > self.safety_checker_threshold:
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image
@@ -624,8 +631,9 @@ class StreamDiffusionWrapper:
             else:
                 denormalized_image_tensor = image
             pixel_values = self.safety_image_transforms(denormalized_image_tensor)
-            predicted_label = self.safety_checker(pixel_values).argmax(-1).item()
-            if predicted_label == 1:
+            logits = self.safety_checker(pixel_values)
+            nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
+            if nsfw_prob > self.safety_checker_threshold:
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image


### PR DESCRIPTION
- adds support to threshold the safety checker basically acting as sensitivity control
- also adds running streak -- the nsfw fallback is only done if the last 3 frames also detected as nsfw