### PR TITLE
upgrade: upgrades safety_checker model

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -304,21 +304,21 @@ class NSFWDetector(BaseModel):
     def get_input_profile(self, batch_size, *args, **kwargs):
         return {
             "pixel_values": [
-                (self.min_batch, 3, 224, 224),
-                (batch_size, 3, 224, 224),
-                (self.max_batch, 3, 224, 224),
+                (self.min_batch, 3, 448, 448),
+                (batch_size, 3, 448, 448),
+                (self.max_batch, 3, 448, 448),
             ],
         }
     
     def get_shape_dict(self, batch_size, *args, **kwargs):
         return {
-            "pixel_values": (batch_size, 3, 224, 224),
+            "pixel_values": (batch_size, 3, 448, 448),
             "logits": (batch_size, 2),
         }
     
     def get_sample_input(self, batch_size, *args, **kwargs):
         return (
-            torch.randn(batch_size, 3, 224, 224, dtype=torch.float16, device=self.device),
+            torch.randn(batch_size, 3, 448, 448, dtype=torch.float16, device=self.device),
         )
 
 class UNet(BaseModel):

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -2,7 +2,6 @@ import os
 import torch
 import logging
 from typing import *
-from enum import Enum
 
 from polygraphy import cuda
 import torch.nn.functional as F
@@ -391,13 +390,6 @@ class SafetyCheckerEngine:
     def forward(self, *args, **kwargs):
         pass
 
-class NSFWLevel(str, Enum):
-    """Enum for NSFW content levels."""
-    NEUTRAL = "neutral"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-
 class NSFWDetectorEngine:
     def __init__(self, filepath: str, stream: 'cuda.Stream', use_cuda_graph: bool = False):
         self.engine = Engine(filepath)
@@ -412,13 +404,10 @@ class NSFWDetectorEngine:
             T.Normalize(mean=[0.4815, 0.4578, 0.4082], std=[0.2686, 0.2613, 0.2758])
         ])
 
-        self.idx_to_label = {NSFWLevel.NEUTRAL: 0, NSFWLevel.LOW: 1, 
-                             NSFWLevel.MEDIUM: 2, NSFWLevel.HIGH: 3}
-
         self.engine.load()
         self.engine.activate()
         
-    def __call__(self, image_tensor: torch.Tensor, threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW, threshold: float = 0.5):
+    def __call__(self, image_tensor: torch.Tensor, threshold: float):
         pixel_values = self.image_transforms(image_tensor)
         self.engine.allocate_buffers(
             shape_dict={
@@ -434,9 +423,8 @@ class NSFWDetectorEngine:
         )["logits"]
 
         probs = F.softmax(logits, dim=-1)
-        cumsum = probs.flip(-1).cumsum(-1).flip(-1)
-        cumsum[..., 0] = probs[..., 0]
-        if cumsum[0][self.idx_to_label[threshold_level]] >= threshold:
+        nsfw_prob = 1 - probs[0, 0].item()
+        if nsfw_prob >= threshold:
             return True
         else:
             return False

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -424,10 +424,7 @@ class NSFWDetectorEngine:
 
         probs = F.softmax(logits, dim=-1)
         nsfw_prob = 1 - probs[0, 0].item()
-        if nsfw_prob >= threshold:
-            return True
-        else:
-            return False
+        return nsfw_prob >= threshold
         
 
     def to(self, *args, **kwargs):  

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -1,13 +1,16 @@
-from typing import *
-
+import os
 import torch
 import logging
-import os
+from typing import *
+from enum import Enum
 
+from polygraphy import cuda
+import torch.nn.functional as F
+import torchvision.transforms as T
+from torchvision.transforms import InterpolationMode
+from diffusers.models.autoencoders.autoencoder_kl import DecoderOutput
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
 from diffusers.models.autoencoders.autoencoder_tiny import AutoencoderTinyOutput
-from diffusers.models.autoencoders.autoencoder_kl import DecoderOutput
-from polygraphy import cuda
 
 from ..utilities import Engine
 
@@ -388,28 +391,56 @@ class SafetyCheckerEngine:
     def forward(self, *args, **kwargs):
         pass
 
+class NSFWLevel(str, Enum):
+    """Enum for NSFW content levels."""
+    NEUTRAL = "neutral"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
 class NSFWDetectorEngine:
     def __init__(self, filepath: str, stream: 'cuda.Stream', use_cuda_graph: bool = False):
         self.engine = Engine(filepath)
         self.stream = stream
         self.use_cuda_graph = use_cuda_graph
 
+        # The resize shape, mean and std are fetched from the model/processor config
+        self.image_transforms = T.Compose([
+            T.Resize(size=(448, 448), interpolation=InterpolationMode.BICUBIC, max_size=None, antialias=True),
+            T.CenterCrop(size=(448, 448)),
+            T.Lambda(lambda x: x.clamp(0, 1)),
+            T.Normalize(mean=[0.4815, 0.4578, 0.4082], std=[0.2686, 0.2613, 0.2758])
+        ])
+
+        self.idx_to_label = {NSFWLevel.NEUTRAL: 0, NSFWLevel.LOW: 1, 
+                             NSFWLevel.MEDIUM: 2, NSFWLevel.HIGH: 3}
+
         self.engine.load()
         self.engine.activate()
         
-    def __call__(self, pixel_values: torch.Tensor):
+    def __call__(self, image_tensor: torch.Tensor, threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW, threshold: float = 0.5):
+        pixel_values = self.image_transforms(image_tensor)
         self.engine.allocate_buffers(
             shape_dict={
                 "pixel_values": pixel_values.shape,
-                "logits": (pixel_values.shape[0], 2),
+                "logits": (pixel_values.shape[0], 4),
             },
             device=pixel_values.device,
         )
-        return self.engine.infer(
+        logits = self.engine.infer(
             {"pixel_values": pixel_values},
             self.stream,    
             use_cuda_graph=self.use_cuda_graph,
         )["logits"]
+
+        probs = F.softmax(logits, dim=-1)
+        cumsum = probs.flip(-1).cumsum(-1).flip(-1)
+        cumsum[..., 0] = probs[..., 0]
+        if cumsum[0][self.idx_to_label[threshold_level]] >= threshold:
+            return True
+        else:
+            return False
+        
 
     def to(self, *args, **kwargs):  
         pass

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -486,7 +486,8 @@ class StreamDiffusionWrapper:
         # IPAdapter configuration
         ipadapter_config: Optional[Dict[str, Any]] = None,
         use_safety_checker: Optional[bool] = None,
-        safety_checker_threshold: Literal["low", "medium", "high"] = None,
+        safety_checker_threshold: Optional[float] = None,
+        safety_checker_threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW,
     ) -> None:
         """
         Update streaming parameters efficiently in a single call.
@@ -555,6 +556,8 @@ class StreamDiffusionWrapper:
             self.use_safety_checker = use_safety_checker
         if safety_checker_threshold is not None:
             self.safety_checker_threshold = safety_checker_threshold
+        if safety_checker_threshold_level is not None:
+            self.safety_checker_threshold_level = safety_checker_threshold_level
 
     def __call__(
         self,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -20,6 +20,13 @@ torch.set_grad_enabled(False)
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
 
+SAFETY_CHECKER_THRESHOLD_MAP = {
+    "neutral": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
 
 class StreamDiffusionWrapper:
     """
@@ -108,9 +115,9 @@ class StreamDiffusionWrapper:
         # IPAdapter options
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        safety_checker_model_id: Optional[str] = "Falconsai/nsfw_image_detection",
+        safety_checker_model_id: Optional[str] = "Freepik/nsfw_image_detector",
         safety_checker_fallback_type: Literal["blank", "previous"] = "previous",
-        safety_checker_threshold: float = 0.95,
+        safety_checker_threshold: Literal["low", "medium", "high"] = "low",
     ):
         """
         Initializes the StreamDiffusionWrapper.
@@ -297,13 +304,13 @@ class StreamDiffusionWrapper:
             )
 
         self.safety_image_transforms = T.Compose([
-            T.Resize(size=(224, 224), interpolation=InterpolationMode.BICUBIC, antialias=True),
-            T.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
+            T.Resize(size=(448, 448), interpolation=InterpolationMode.BICUBIC, antialias=True),
+            T.Lambda(lambda x: x.clamp(0, 1)),
+            T.Normalize(mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711])
         ])
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
-        self.safety_checker_threshold = safety_checker_threshold
-        self.safety_checker_streak = 0
+        self.safety_checker_threshold = SAFETY_CHECKER_THRESHOLD_MAP[safety_checker_threshold]
 
     def prepare(
         self,
@@ -481,7 +488,7 @@ class StreamDiffusionWrapper:
         # IPAdapter configuration
         ipadapter_config: Optional[Dict[str, Any]] = None,
         use_safety_checker: Optional[bool] = None,
-        safety_checker_threshold: Optional[float] = None,
+        safety_checker_threshold: Literal["low", "medium", "high"] = None,
     ) -> None:
         """
         Update streaming parameters efficiently in a single call.
@@ -549,7 +556,7 @@ class StreamDiffusionWrapper:
         if use_safety_checker is not None:
             self.use_safety_checker = use_safety_checker
         if safety_checker_threshold is not None:
-            self.safety_checker_threshold = safety_checker_threshold
+            self.safety_checker_threshold = SAFETY_CHECKER_THRESHOLD_MAP[safety_checker_threshold]
 
     def __call__(
         self,
@@ -609,15 +616,11 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = image
             pixel_values = self.safety_image_transforms(denormalized_image_tensor)
             logits = self.safety_checker(pixel_values)
-            nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
-            if nsfw_prob > self.safety_checker_threshold:
-                self.safety_checker_streak += 1
-                if self.safety_checker_streak > 3:
-                    image = self.nsfw_fallback_img
-            else:
-                self.safety_checker_streak = 0
-                if self.safety_checker_fallback_type == "previous":
-                    self.nsfw_fallback_img = image
+            prediction_label = logits.argmax(-1).item()
+            if prediction_label >= self.safety_checker_threshold:
+                image = self.nsfw_fallback_img
+            elif self.safety_checker_fallback_type == "previous":
+                self.nsfw_fallback_img = image
 
         return image
 
@@ -655,15 +658,11 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = image
             pixel_values = self.safety_image_transforms(denormalized_image_tensor)
             logits = self.safety_checker(pixel_values)
-            nsfw_prob = torch.softmax(logits, dim=-1)[0][1].item()
-            if nsfw_prob > self.safety_checker_threshold:
-                self.safety_checker_streak += 1
-                if self.safety_checker_streak > 3:
-                    image = self.nsfw_fallback_img
-            else:
-                self.safety_checker_streak = 0
-                if self.safety_checker_fallback_type == "previous":
-                    self.nsfw_fallback_img = image
+            prediction_label = logits.argmax(-1).item()
+            if prediction_label >= self.safety_checker_threshold:
+                image = self.nsfw_fallback_img
+            elif self.safety_checker_fallback_type == "previous":
+                self.nsfw_fallback_img = image
 
         return image
 
@@ -824,7 +823,7 @@ class StreamDiffusionWrapper:
         controlnet_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        safety_checker_model_id: Optional[str] = "Falconsai/nsfw_image_detection",
+        safety_checker_model_id: Optional[str] = "Freepik/nsfw_image_detector",
         compile_engines_only: bool = False,
     ) -> StreamDiffusion:
         """

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -10,7 +10,6 @@ from diffusers import AutoencoderTiny, StableDiffusionPipeline, StableDiffusionX
 from .pipeline import StreamDiffusion
 from .model_detection import detect_model
 from .image_utils import postprocess_image
-from .acceleration.tensorrt.runtime_engines.unet_engine import NSFWLevel
 
 import logging
 logger = logging.getLogger(__name__)
@@ -108,7 +107,6 @@ class StreamDiffusionWrapper:
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
         safety_checker_fallback_type: Literal["blank", "previous"] = "previous",
-        safety_checker_threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW,
         safety_checker_threshold: float = 0.5,
     ):
         """
@@ -190,17 +188,8 @@ class StreamDiffusionWrapper:
             Each config should contain: model_id, preprocessor (optional), conditioning_scale, etc.
         safety_checker_fallback_type : Literal["blank", "previous"], optional
             Whether to use a blank image or the previous image as a fallback, by default "previous".
-        safety_checker_threshold_level : Literal["low", "medium", "high"], optional
-            Sensitivity level for NSFW detection using the Freepik classifier. The
-            model computes a cumulative NSFW probability at or above the chosen
-            level: "low" = P(low)+P(medium)+P(high), "medium" = P(medium)+P(high),
-            "high" = P(high). An image is flagged NSFW if this cumulative score is
-            greater than or equal to ``safety_checker_threshold``. Defaults to "low"
-            (most sensitive).
-        safety_checker_threshold : float, optional
-            Probability cutoff in [0.0, 1.0] applied to the cumulative score defined
-            by ``safety_checker_threshold_level``. Frames at or above this value are
-            treated as NSFW and will trigger the configured fallback. Defaults to 0.5.
+        safety_checker_threshold: float, optional
+            The threshold for the safety checker, by default 0.5.
         compile_engines_only : bool, optional
             Whether to only compile engines and not load the model, by default False.
         """
@@ -266,9 +255,6 @@ class StreamDiffusionWrapper:
             controlnet_config=controlnet_config,
             use_ipadapter=use_ipadapter,
             ipadapter_config=ipadapter_config,
-            safety_checker_threshold_level=safety_checker_threshold_level,
-            safety_checker_threshold=safety_checker_threshold,
-            compile_engines_only=compile_engines_only,
         )
 
         if compile_engines_only:
@@ -308,7 +294,6 @@ class StreamDiffusionWrapper:
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
         self.safety_checker_threshold = safety_checker_threshold
-        self.safety_checker_threshold_level = safety_checker_threshold_level
 
     def prepare(
         self,
@@ -487,7 +472,6 @@ class StreamDiffusionWrapper:
         ipadapter_config: Optional[Dict[str, Any]] = None,
         use_safety_checker: Optional[bool] = None,
         safety_checker_threshold: Optional[float] = None,
-        safety_checker_threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW,
     ) -> None:
         """
         Update streaming parameters efficiently in a single call.
@@ -531,9 +515,6 @@ class StreamDiffusionWrapper:
             IPAdapter configuration dict containing scale, style_image, etc.
         use_safety_checker : Optional[bool]
             Whether to use the safety checker.
-        safety_checker_threshold : Optional[float]
-            Probability threshold for the safety checker (0.0–1.0). Frames with
-            NSFW probability above this value will trigger the configured fallback.
         """
         # Handle all parameters via parameter updater (including ControlNet)
         self.stream._param_updater.update_stream_params(
@@ -556,8 +537,6 @@ class StreamDiffusionWrapper:
             self.use_safety_checker = use_safety_checker
         if safety_checker_threshold is not None:
             self.safety_checker_threshold = safety_checker_threshold
-        if safety_checker_threshold_level is not None:
-            self.safety_checker_threshold_level = safety_checker_threshold_level
 
     def __call__(
         self,
@@ -615,9 +594,7 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = (image_tensor / 2 + 0.5).clamp(0, 1).to(self.device)
             else:
                 denormalized_image_tensor = image
-            is_nsfw = self.safety_checker(denormalized_image_tensor, 
-                    self.safety_checker_threshold_level, self.safety_checker_threshold)
-            if is_nsfw:
+            if self.safety_checker(denormalized_image_tensor, self.safety_checker_threshold):
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image
@@ -656,12 +633,7 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = (image_tensor / 2 + 0.5).clamp(0, 1).to(self.device)
             else:
                 denormalized_image_tensor = image
-            is_nsfw = self.safety_checker(
-                        denormalized_image_tensor, 
-                        self.safety_checker_threshold_level, 
-                        self.safety_checker_threshold
-                    )
-            if is_nsfw:
+            if self.safety_checker(denormalized_image_tensor, self.safety_checker_threshold):
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image
@@ -826,8 +798,6 @@ class StreamDiffusionWrapper:
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
         safety_checker_model_id: Optional[str] = "Freepik/nsfw_image_detector",
-        safety_checker_threshold_level: Literal["low", "medium", "high"] = "low",
-        safety_checker_threshold: float = 0.5,
         compile_engines_only: bool = False,
     ) -> StreamDiffusion:
         """

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -5,13 +5,12 @@ from typing import Dict, List, Literal, Optional, Union, Any, Tuple
 import torch
 import numpy as np
 from PIL import Image
-import torchvision.transforms as T
-from torchvision.transforms import InterpolationMode
 from diffusers import AutoencoderTiny, StableDiffusionPipeline, StableDiffusionXLPipeline, AutoPipelineForText2Image
 
 from .pipeline import StreamDiffusion
 from .model_detection import detect_model
 from .image_utils import postprocess_image
+from .acceleration.tensorrt.runtime_engines.unet_engine import NSFWLevel
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,13 +18,6 @@ logger = logging.getLogger(__name__)
 torch.set_grad_enabled(False)
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
-
-SAFETY_CHECKER_THRESHOLD_MAP = {
-    "neutral": 0,
-    "low": 1,
-    "medium": 2,
-    "high": 3,
-}
 
 
 class StreamDiffusionWrapper:
@@ -115,9 +107,9 @@ class StreamDiffusionWrapper:
         # IPAdapter options
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        safety_checker_model_id: Optional[str] = "Freepik/nsfw_image_detector",
         safety_checker_fallback_type: Literal["blank", "previous"] = "previous",
-        safety_checker_threshold: Literal["low", "medium", "high"] = "low",
+        safety_checker_threshold_level: Literal[NSFWLevel.LOW, NSFWLevel.MEDIUM, NSFWLevel.HIGH] = NSFWLevel.LOW,
+        safety_checker_threshold: float = 0.5,
     ):
         """
         Initializes the StreamDiffusionWrapper.
@@ -198,8 +190,17 @@ class StreamDiffusionWrapper:
             Each config should contain: model_id, preprocessor (optional), conditioning_scale, etc.
         safety_checker_fallback_type : Literal["blank", "previous"], optional
             Whether to use a blank image or the previous image as a fallback, by default "previous".
+        safety_checker_threshold_level : Literal["low", "medium", "high"], optional
+            Sensitivity level for NSFW detection using the Freepik classifier. The
+            model computes a cumulative NSFW probability at or above the chosen
+            level: "low" = P(low)+P(medium)+P(high), "medium" = P(medium)+P(high),
+            "high" = P(high). An image is flagged NSFW if this cumulative score is
+            greater than or equal to ``safety_checker_threshold``. Defaults to "low"
+            (most sensitive).
         safety_checker_threshold : float, optional
-            The threshold for the safety checker, by default 0.95.
+            Probability cutoff in [0.0, 1.0] applied to the cumulative score defined
+            by ``safety_checker_threshold_level``. Frames at or above this value are
+            treated as NSFW and will trigger the configured fallback. Defaults to 0.5.
         compile_engines_only : bool, optional
             Whether to only compile engines and not load the model, by default False.
         """
@@ -265,7 +266,8 @@ class StreamDiffusionWrapper:
             controlnet_config=controlnet_config,
             use_ipadapter=use_ipadapter,
             ipadapter_config=ipadapter_config,
-            safety_checker_model_id=safety_checker_model_id,
+            safety_checker_threshold_level=safety_checker_threshold_level,
+            safety_checker_threshold=safety_checker_threshold,
             compile_engines_only=compile_engines_only,
         )
 
@@ -303,14 +305,10 @@ class StreamDiffusionWrapper:
                 similar_image_filter_threshold, similar_image_filter_max_skip_frame
             )
 
-        self.safety_image_transforms = T.Compose([
-            T.Resize(size=(448, 448), interpolation=InterpolationMode.BICUBIC, antialias=True),
-            T.Lambda(lambda x: x.clamp(0, 1)),
-            T.Normalize(mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711])
-        ])
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
-        self.safety_checker_threshold = SAFETY_CHECKER_THRESHOLD_MAP[safety_checker_threshold]
+        self.safety_checker_threshold = safety_checker_threshold
+        self.safety_checker_threshold_level = safety_checker_threshold_level
 
     def prepare(
         self,
@@ -556,7 +554,7 @@ class StreamDiffusionWrapper:
         if use_safety_checker is not None:
             self.use_safety_checker = use_safety_checker
         if safety_checker_threshold is not None:
-            self.safety_checker_threshold = SAFETY_CHECKER_THRESHOLD_MAP[safety_checker_threshold]
+            self.safety_checker_threshold = safety_checker_threshold
 
     def __call__(
         self,
@@ -614,10 +612,9 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = (image_tensor / 2 + 0.5).clamp(0, 1).to(self.device)
             else:
                 denormalized_image_tensor = image
-            pixel_values = self.safety_image_transforms(denormalized_image_tensor)
-            logits = self.safety_checker(pixel_values)
-            prediction_label = logits.argmax(-1).item()
-            if prediction_label >= self.safety_checker_threshold:
+            is_nsfw = self.safety_checker(denormalized_image_tensor, 
+                    self.safety_checker_threshold_level, self.safety_checker_threshold)
+            if is_nsfw:
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image
@@ -656,10 +653,12 @@ class StreamDiffusionWrapper:
                 denormalized_image_tensor = (image_tensor / 2 + 0.5).clamp(0, 1).to(self.device)
             else:
                 denormalized_image_tensor = image
-            pixel_values = self.safety_image_transforms(denormalized_image_tensor)
-            logits = self.safety_checker(pixel_values)
-            prediction_label = logits.argmax(-1).item()
-            if prediction_label >= self.safety_checker_threshold:
+            is_nsfw = self.safety_checker(
+                        denormalized_image_tensor, 
+                        self.safety_checker_threshold_level, 
+                        self.safety_checker_threshold
+                    )
+            if is_nsfw:
                 image = self.nsfw_fallback_img
             elif self.safety_checker_fallback_type == "previous":
                 self.nsfw_fallback_img = image
@@ -824,6 +823,8 @@ class StreamDiffusionWrapper:
         use_ipadapter: bool = False,
         ipadapter_config: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
         safety_checker_model_id: Optional[str] = "Freepik/nsfw_image_detector",
+        safety_checker_threshold_level: Literal["low", "medium", "high"] = "low",
+        safety_checker_threshold: float = 0.5,
         compile_engines_only: bool = False,
     ) -> StreamDiffusion:
         """


### PR DESCRIPTION
- upgrades safety_checker model due to false positives to a better model `Freepik/nsfw_image_detector` which is more suitable for AI generated images
- threshold now is between three options ["low", "medium", "high"] instead of percentage/probability
- removed the streak logic as it wasn't work as expected
- models runs on bigger size inputs (448 v 224) compared to the older `Falconsai/nsfw_image_detection` model probably why the improvement in accuracy and so the model is slower (2 ms v 0.9 ms) compared the older model but 2ms is something we can afford

following is mentioned on the models huggingface hub readme:

```
- Avoid using Falconsai for AI-generated content to prevent prediction errors.
- Our model is the best option to detect NSFW content in AI-generated content.
```