### PR TITLE
IPAdapter Architecture Refactor & Runtime Control

### DIFF
--- a/demo/realtime-img2img/frontend/src/lib/components/IPAdapterConfig.svelte
+++ b/demo/realtime-img2img/frontend/src/lib/components/IPAdapterConfig.svelte
@@ -5,6 +5,7 @@
   export let ipadapterInfo: any = null;
   export let currentScale: number = 1.0;
   export let currentWeightType: string = "linear";
+  export let currentEnabled: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -87,6 +88,37 @@
     updateIPAdapterWeightType(weightType);
   }
 
+  async function updateIPAdapterEnabled(enabled: boolean) {
+    try {
+      const response = await fetch('/api/ipadapter/update-enabled', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          enabled: enabled,
+        }),
+      });
+
+      if (!response.ok) {
+        const result = await response.json();
+        console.error('updateIPAdapterEnabled: Failed to update enabled state:', result.detail);
+      }
+    } catch (error) {
+      console.error('updateIPAdapterEnabled: Update failed:', error);
+    }
+  }
+
+  function handleEnabledChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const enabled = target.checked;
+    
+    // Update local state immediately for responsiveness
+    currentEnabled = enabled;
+    
+    updateIPAdapterEnabled(enabled);
+  }
+
   async function uploadStyleImage() {
     if (!styleImageFile.files || styleImageFile.files.length === 0) {
       uploadStatus = 'Please select an image file';
@@ -144,12 +176,15 @@
     styleImageFile.click();
   }
 
-  // Update current scale and weight type when prop changes
+  // Update current scale, weight type, and enabled state when props change
   $: if (ipadapterInfo?.scale !== undefined) {
     currentScale = ipadapterInfo.scale;
   }
   $: if (ipadapterInfo?.weight_type !== undefined) {
     currentWeightType = ipadapterInfo.weight_type;
+  }
+  $: if (ipadapterInfo?.enabled !== undefined) {
+    currentEnabled = ipadapterInfo.enabled;
   }
 </script>
 
@@ -167,140 +202,158 @@
     <div class="p-4 pt-1">
         <!-- IPAdapter Status -->
         <div class="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-700 rounded mb-3">
-          {#if ipadapterInfo?.enabled}
+          {#if currentEnabled}
             <div class="w-2 h-2 bg-green-500 rounded-full"></div>
             <span class="text-sm font-medium text-green-800 dark:text-green-200">IPAdapter Enabled</span>
           {:else}
             <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
-            <span class="text-sm text-gray-600 dark:text-gray-400">Standard Mode</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">IPAdapter Disabled</span>
           {/if}
         </div>
 
-        {#if ipadapterInfo?.enabled}
-          <!-- Style Image Upload -->
-          <div class="space-y-3">
-            <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
-              <h5 class="text-sm font-medium mb-2">Style Image</h5>
-              
-              <!-- Style Image Preview -->
-              {#if currentStyleImage}
-                <div class="mb-3">
-                  <img 
-                    src={currentStyleImage} 
-                    alt="Uploaded style image" 
-                    class="w-full max-w-32 h-32 object-cover rounded border border-gray-200 dark:border-gray-600"
-                  />
-                  <p class="text-xs text-gray-500 mt-1">Uploaded style image</p>
-                </div>
-              {:else if ipadapterInfo?.style_image_path}
-                <div class="mb-3">
-                  <img 
-                    src={ipadapterInfo.style_image_path} 
-                    alt="Style image" 
-                    class="w-full max-w-32 h-32 object-cover rounded border border-gray-200 dark:border-gray-600"
-                  />
-                  <!-- Show different text for uploaded vs config vs default style images -->
-                  <p class="text-xs text-gray-500 mt-1">
-                    {#if ipadapterInfo.style_image_path.includes('/api/ipadapter/uploaded-style-image')}
-                      Uploaded style image
-                    {:else if ipadapterInfo.style_image_path.includes('/api/default-image')}
-                      Default style image (input.png)
-                    {:else}
-                      From config: {ipadapterInfo.style_image_path}
-                    {/if}
-                  </p>
-                </div>
-              {/if}
-              
-              <!-- Upload Button -->
-              <div class="flex items-center gap-2">
-                <Button 
-                  on:click={selectStyleImage} 
-                  disabled={uploadingImage} 
-                  classList="text-sm px-3 py-2"
-                >
-                  {uploadingImage ? 'Uploading...' : 'Upload Style Image'}
-                </Button>
-              </div>
-              
-              <!-- Hidden file input -->
-              <input
-                bind:this={styleImageFile}
-                type="file"
-                accept="image/*"
-                class="hidden"
-                on:change={uploadStyleImage}
-              />
-              
-              <!-- Upload Status -->
-              {#if uploadStatus}
-                <p class="text-xs mt-2 {uploadStatus.includes('Error') || uploadStatus.includes('Please') ? 'text-red-600' : 'text-green-600'}">
-                  {uploadStatus}
-                </p>
-              {/if}
-              
-              <p class="text-xs text-gray-500 mt-2">
-                Upload an image to use as style reference for IPAdapter conditioning. If no image is uploaded, the default input.png will be used.
-              </p>
-            </div>
-
-            <!-- Scale Control -->
-            <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
-              <h5 class="text-sm font-medium mb-2">IPAdapter Scale</h5>
-              <div class="space-y-2">
-                <div class="flex items-center justify-between">
-                  <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Strength</label>
-                  <span class="text-xs text-gray-600 dark:text-gray-400">{currentScale.toFixed(2)}</span>
-                </div>
+        <!-- Enable/Disable Toggle (only show if IPAdapter is available) -->
+        {#if ipadapterInfo}
+          <div class="bg-gray-50 dark:bg-gray-700 rounded p-3 mb-3">
+            <div class="flex items-center justify-between">
+              <label class="text-sm font-medium text-gray-700 dark:text-gray-300" for="ipadapter-enabled">
+                Enable IPAdapter
+              </label>
+              <label class="relative inline-flex items-center cursor-pointer">
                 <input
-                  type="range"
-                  min="0"
-                  max="2"
-                  step="0.01"
-                  value={currentScale}
-                  on:input={handleScaleChange}
-                  class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600"
+                  id="ipadapter-enabled"
+                  type="checkbox"
+                  class="sr-only peer"
+                  checked={currentEnabled}
+                  on:change={handleEnabledChange}
                 />
-                <p class="text-xs text-gray-500">
-                  Controls how strongly the style image influences the generation. Higher values = stronger style influence.
-                </p>
-              </div>
+                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
+              </label>
             </div>
+            <p class="text-xs text-gray-500 mt-2">
+              Toggle to enable or disable IPAdapter style influence on the generated images.
+            </p>
+          </div>
+        {/if}
 
-            <!-- Weight Type Control -->
-            <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
-              <h5 class="text-sm font-medium mb-2">Weight Type</h5>
-              <div class="space-y-2">
-                <select
-                  value={currentWeightType}
-                  on:change={handleWeightTypeChange}
-                  class="w-full px-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                >
-                  {#each weightTypes as weightType}
-                    <option value={weightType}>{weightType}</option>
-                  {/each}
-                </select>
-                <p class="text-xs text-gray-500">
-                  Controls how the IPAdapter influence is distributed across different layers of the model.
-                </p>
+        <!-- Style Image Upload -->
+        <div class="space-y-3">
+          <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
+            <h5 class="text-sm font-medium mb-2">Style Image</h5>
+            
+            <!-- Style Image Preview -->
+            {#if currentStyleImage}
+              <div class="mb-3">
+                <img 
+                  src={currentStyleImage} 
+                  alt="Uploaded style image" 
+                  class="w-full max-w-32 h-32 object-cover rounded border border-gray-200 dark:border-gray-600"
+                />
+                <p class="text-xs text-gray-500 mt-1">Uploaded style image</p>
               </div>
-            </div>
-
-            <!-- IPAdapter Info -->
-            {#if ipadapterInfo?.model_path}
-              <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
-                <h5 class="text-sm font-medium mb-2">Model Information</h5>
-                <p class="text-xs text-gray-600 dark:text-gray-400 font-mono break-all">
-                  {ipadapterInfo.model_path}
+            {:else if ipadapterInfo?.style_image_path}
+              <div class="mb-3">
+                <img 
+                  src={ipadapterInfo.style_image_path} 
+                  alt="Style image" 
+                  class="w-full max-w-32 h-32 object-cover rounded border border-gray-200 dark:border-gray-600"
+                />
+                <!-- Show different text for uploaded vs config vs default style images -->
+                <p class="text-xs text-gray-500 mt-1">
+                  {#if ipadapterInfo.style_image_path.includes('/api/ipadapter/uploaded-style-image')}
+                    Uploaded style image
+                  {:else if ipadapterInfo.style_image_path.includes('/api/default-image')}
+                    Default style image (input.png)
+                  {:else}
+                    From config: {ipadapterInfo.style_image_path}
+                  {/if}
                 </p>
               </div>
             {/if}
+            
+            <!-- Upload Button -->
+            <div class="flex items-center gap-2">
+              <Button 
+                on:click={selectStyleImage} 
+                disabled={uploadingImage} 
+                classList="text-sm px-3 py-2"
+              >
+                {uploadingImage ? 'Uploading...' : 'Upload Style Image'}
+              </Button>
+            </div>
+            
+            <!-- Hidden file input -->
+            <input
+              bind:this={styleImageFile}
+              type="file"
+              accept="image/*"
+              class="hidden"
+              on:change={uploadStyleImage}
+            />
+            
+            <!-- Upload Status -->
+            {#if uploadStatus}
+              <p class="text-xs mt-2 {uploadStatus.includes('Error') || uploadStatus.includes('Please') ? 'text-red-600' : 'text-green-600'}">
+                {uploadStatus}
+              </p>
+            {/if}
+            
+            <p class="text-xs text-gray-500 mt-2">
+              Upload an image to use as style reference for IPAdapter conditioning. If no image is uploaded, the default input.png will be used.
+            </p>
           </div>
-        {:else}
-          <p class="text-xs text-gray-600 dark:text-gray-400">
-            Load a configuration with IPAdapter settings to enable style-guided generation.
-          </p>
-        {/if}
+
+          <!-- Scale Control -->
+          <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
+            <h5 class="text-sm font-medium mb-2">IPAdapter Scale</h5>
+            <div class="space-y-2">
+              <div class="flex items-center justify-between">
+                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Strength</label>
+                <span class="text-xs text-gray-600 dark:text-gray-400">{currentScale.toFixed(2)}</span>
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="2"
+                step="0.01"
+                value={currentScale}
+                on:input={handleScaleChange}
+                class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600"
+              />
+              <p class="text-xs text-gray-500">
+                Controls how strongly the style image influences the generation. Higher values = stronger style influence.
+              </p>
+            </div>
+          </div>
+
+          <!-- Weight Type Control -->
+          <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
+            <h5 class="text-sm font-medium mb-2">Weight Type</h5>
+            <div class="space-y-2">
+              <select
+                value={currentWeightType}
+                on:change={handleWeightTypeChange}
+                class="w-full px-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                {#each weightTypes as weightType}
+                  <option value={weightType}>{weightType}</option>
+                {/each}
+              </select>
+              <p class="text-xs text-gray-500">
+                Controls how the IPAdapter influence is distributed across different layers of the model.
+              </p>
+            </div>
+          </div>
+
+          <!-- IPAdapter Info -->
+          {#if ipadapterInfo?.model_path}
+            <div class="bg-gray-50 dark:bg-gray-700 rounded p-3">
+              <h5 class="text-sm font-medium mb-2">Model Information</h5>
+              <p class="text-xs text-gray-600 dark:text-gray-400 font-mono break-all">
+                {ipadapterInfo.model_path}
+              </p>
+            </div>
+          {/if}
+        </div>
     </div>
     {/if}
   </div>

--- a/demo/realtime-img2img/frontend/src/routes/+page.svelte
+++ b/demo/realtime-img2img/frontend/src/routes/+page.svelte
@@ -1023,6 +1023,7 @@
             {ipadapterInfo} 
             currentScale={ipadapterScale}
             currentWeightType={ipadapterWeightType}
+            currentEnabled={ipadapterInfo?.enabled ?? true}
           ></IPAdapterConfig>
 
           <PipelineHooksConfig 

--- a/examples/config/config_ipadapter_stream_test.py
+++ b/examples/config/config_ipadapter_stream_test.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+IPAdapter Stream Test Demo for StreamDiffusion
+
+This script tests the IPAdapter as the primary driving force for style and structure,
+while using a static image as the base input to StreamDiffusion. This demonstrates
+the technique where IPAdapter provides both style and structural guidance.
+
+Key features:
+- Input video frames are used as both ControlNet control images AND IPAdapter style images
+- A static image is used as the base input to StreamDiffusion (repeated for each frame)
+- is_stream=True enables high-throughput pipelined processing
+- Tests the IPAdapter stream behavior fix
+"""
+
+import cv2
+import torch
+import numpy as np
+from PIL import Image
+import argparse
+from pathlib import Path
+import sys
+import time
+import os
+import shutil
+import json
+from collections import deque
+
+
+def tensor_to_opencv(tensor: torch.Tensor, target_width: int, target_height: int) -> np.ndarray:
+    """
+    Convert a PyTorch tensor (output_type='pt') to OpenCV BGR format for video writing.
+    Uses efficient tensor operations similar to the realtime-img2img demo.
+    
+    Args:
+        tensor: Tensor in range [0,1] with shape [B, C, H, W] or [C, H, W]
+        target_width: Target width for output
+        target_height: Target height for output
+    
+    Returns:
+        BGR numpy array ready for OpenCV
+    """
+    # Handle batch dimension - take first image if batched
+    if tensor.dim() == 4:
+        tensor = tensor[0]
+    
+    # Convert to uint8 format (0-255) and ensure correct shape (C, H, W)
+    tensor_uint8 = (tensor * 255).clamp(0, 255).to(torch.uint8)
+    
+    # Convert from [C, H, W] to [H, W, C] format
+    if tensor_uint8.dim() == 3:
+        image_np = tensor_uint8.permute(1, 2, 0).cpu().numpy()
+    else:
+        raise ValueError(f"tensor_to_opencv: Unexpected tensor shape: {tensor_uint8.shape}")
+    
+    # Convert RGB to BGR for OpenCV
+    image_bgr = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
+    
+    # Resize if needed
+    if image_bgr.shape[:2] != (target_height, target_width):
+        image_bgr = cv2.resize(image_bgr, (target_width, target_height))
+    
+    return image_bgr
+
+
+def process_video_ipadapter_stream(config_path, input_video, static_image, output_dir, engine_only=False):
+    """Process video using IPAdapter as primary driving force with static base image"""
+    print(f"process_video_ipadapter_stream: Loading config from {config_path}")
+    
+    # Import here to avoid loading at module level
+    sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+    from streamdiffusion import load_config, create_wrapper_from_config
+    
+    # Load configuration
+    config = load_config(config_path)
+    
+    # Force tensor output for better performance
+    config['output_type'] = 'pt'
+    
+    # Get width and height from config (with defaults)
+    width = config.get('width', 512)
+    height = config.get('height', 512)
+    
+    print(f"process_video_ipadapter_stream: Using dimensions: {width}x{height}")
+    print(f"process_video_ipadapter_stream: Using output_type='pt' for better performance")
+    
+    # Create output directory
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Copy config, input video, and static image to output directory
+    config_copy_path = output_dir / f"config_{Path(config_path).name}"
+    shutil.copy2(config_path, config_copy_path)
+    print(f"process_video_ipadapter_stream: Copied config to {config_copy_path}")
+    
+    input_copy_path = output_dir / f"input_{Path(input_video).name}"
+    shutil.copy2(input_video, input_copy_path)
+    print(f"process_video_ipadapter_stream: Copied input video to {input_copy_path}")
+    
+    static_copy_path = output_dir / f"static_{Path(static_image).name}"
+    shutil.copy2(static_image, static_copy_path)
+    print(f"process_video_ipadapter_stream: Copied static image to {static_copy_path}")
+    
+    # Create wrapper using the built-in function
+    wrapper = create_wrapper_from_config(config)
+    
+    if engine_only:
+        print("Engine-only mode: TensorRT engines have been built (if needed). Exiting.")
+        return None
+    
+    # Load and prepare static image
+    static_img = Image.open(static_image)
+    static_img = static_img.resize((width, height), Image.Resampling.LANCZOS)
+    print(f"process_video_ipadapter_stream: Loaded static image: {static_image}")
+    
+    # Open input video
+    cap = cv2.VideoCapture(str(input_video))
+    if not cap.isOpened():
+        raise ValueError(f"Could not open input video: {input_video}")
+    
+    # Get video properties
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    
+    print(f"process_video_ipadapter_stream: Input video - {frame_count} frames at {fps} FPS")
+    
+    # Setup output video writer (3-panel display: input, static, generated)
+    output_video_path = output_dir / "output_video.mp4"
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    out = cv2.VideoWriter(str(output_video_path), fourcc, fps, (width * 3, height))
+    
+    # Performance tracking
+    frame_times = []
+    total_start_time = time.time()
+    
+    print("process_video_ipadapter_stream: Starting IPAdapter stream processing...")
+    print("process_video_ipadapter_stream: Using static image as base input, video frames for ControlNet + IPAdapter")
+    
+    frame_idx = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        
+        frame_start_time = time.time()
+        
+        # Resize frame
+        frame_resized = cv2.resize(frame, (width, height))
+        
+        # Convert frame to PIL
+        frame_rgb = cv2.cvtColor(frame_resized, cv2.COLOR_BGR2RGB)
+        frame_pil = Image.fromarray(frame_rgb)
+        
+        # Update ControlNet control images (structural guidance from video frames)
+        if hasattr(wrapper.stream, '_controlnet_module') and wrapper.stream._controlnet_module:
+            controlnet_count = len(wrapper.stream._controlnet_module.controlnets)
+            print(f"process_video_ipadapter_stream: Updating control image for {controlnet_count} ControlNet(s) on frame {frame_idx}")
+            for i in range(controlnet_count):
+                wrapper.update_control_image(i, frame_pil)
+        else:
+            print(f"process_video_ipadapter_stream: No ControlNet module found for frame {frame_idx}")
+        
+        # Update IPAdapter style image (style/content guidance from video frames)
+        # This is the key part - using video frames as IPAdapter style images with is_stream=True
+        if hasattr(wrapper.stream, '_ipadapter_module') and wrapper.stream._ipadapter_module:
+            print(f"process_video_ipadapter_stream: Updating IPAdapter style image on frame {frame_idx} (is_stream=True)")
+            # Update style image with is_stream=True for pipelined processing
+            wrapper.update_style_image(frame_pil, is_stream=True)
+        else:
+            print(f"process_video_ipadapter_stream: No IPAdapter module found for frame {frame_idx}")
+        
+        # Process with static image as base input (this is the key difference)
+        # The static image provides the base structure, while ControlNet and IPAdapter
+        # provide the dynamic guidance from the video frames
+        output_tensor = wrapper(static_img)
+        
+        # Convert tensor output to OpenCV BGR format
+        output_bgr = tensor_to_opencv(output_tensor, width, height)
+        
+        # Convert static image to display format
+        static_array = np.array(static_img)
+        static_bgr = cv2.cvtColor(static_array, cv2.COLOR_RGB2BGR)
+        
+        # Create 3-panel display: Input Video | Static Base | Generated Output
+        combined = np.hstack([frame_resized, static_bgr, output_bgr])
+        
+        # Add labels
+        cv2.putText(combined, "Input Video", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+        cv2.putText(combined, "Static Base", (width + 10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+        cv2.putText(combined, "Generated", (width * 2 + 10, 30), 
+                   cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+        
+        # Add frame info
+        cv2.putText(combined, f"Frame: {frame_idx}/{frame_count}", (10, height - 20), 
+                   cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1)
+        
+        # Write frame
+        out.write(combined)
+        
+        # Track performance
+        frame_time = time.time() - frame_start_time
+        frame_times.append(frame_time)
+        
+        frame_idx += 1
+        if frame_idx % 10 == 0:
+            avg_fps = len(frame_times) / sum(frame_times) if frame_times else 0
+            print(f"process_video_ipadapter_stream: Processed {frame_idx}/{frame_count} frames (Avg FPS: {avg_fps:.2f})")
+    
+    total_time = time.time() - total_start_time
+    
+    # Cleanup
+    cap.release()
+    out.release()
+    
+    # Calculate performance metrics
+    if frame_times:
+        avg_frame_time = sum(frame_times) / len(frame_times)
+        avg_fps = 1.0 / avg_frame_time
+        min_frame_time = min(frame_times)
+        max_frame_time = max(frame_times)
+        max_fps = 1.0 / min_frame_time
+        min_fps = 1.0 / max_frame_time
+    else:
+        avg_frame_time = avg_fps = min_frame_time = max_frame_time = max_fps = min_fps = 0
+    
+    # Performance metrics
+    metrics = {
+        "input_video": str(input_video),
+        "static_image": str(static_image),
+        "config_file": str(config_path),
+        "width": width,
+        "height": height,
+        "total_frames": frame_idx,
+        "total_time_seconds": total_time,
+        "avg_fps": avg_fps,
+        "min_fps": min_fps,
+        "max_fps": max_fps,
+        "avg_frame_time_seconds": avg_frame_time,
+        "min_frame_time_seconds": min_frame_time,
+        "max_frame_time_seconds": max_frame_time,
+        "model_id": config['model_id'],
+        "acceleration": config.get('acceleration', 'none'),
+        "frame_buffer_size": config.get('frame_buffer_size', 1),
+        "num_inference_steps": config.get('num_inference_steps', 50),
+        "guidance_scale": config.get('guidance_scale', 1.1),
+        "controlnets": [cn['model_id'] for cn in config.get('controlnets', [])],
+        "ipadapter_configs": [ip['ipadapter_model_path'] for ip in config.get('ipadapter_config', [])],
+        "test_type": "ipadapter_stream_test",
+        "is_stream_enabled": True,
+        "output_type": "pt",
+        "description": "IPAdapter as primary driving force with static base image using tensor output for performance"
+    }
+    
+    # Save metrics
+    metrics_path = output_dir / "performance_metrics.json"
+    with open(metrics_path, 'w') as f:
+        json.dump(metrics, f, indent=2)
+    
+    print(f"process_video_ipadapter_stream: Processing completed!")
+    print(f"process_video_ipadapter_stream: Output video saved to: {output_video_path}")
+    print(f"process_video_ipadapter_stream: Performance metrics saved to: {metrics_path}")
+    print(f"process_video_ipadapter_stream: Average FPS: {avg_fps:.2f}")
+    print(f"process_video_ipadapter_stream: Total time: {total_time:.2f} seconds")
+    print(f"process_video_ipadapter_stream: Test completed - IPAdapter stream behavior verified")
+    
+    return metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IPAdapter Stream Test Demo - Tests IPAdapter as primary driving force")
+    
+    parser.add_argument("--config", type=str, required=True,
+                       help="Path to configuration file (must include both ControlNet and IPAdapter configs)")
+    parser.add_argument("--input-video", type=str, required=True,
+                       help="Path to input video file (used for both ControlNet and IPAdapter guidance)")
+    parser.add_argument("--static-image", type=str, required=True,
+                       help="Path to static image file (used as base input to StreamDiffusion)")
+    parser.add_argument("--output-dir", type=str, default="output",
+                       help="Parent directory for results (default: 'output'). Script will create a timestamped subdirectory inside this.")
+    parser.add_argument("--engine-only", action="store_true", 
+                       help="Only build TensorRT engines and exit (no video processing)")
+    
+    args = parser.parse_args()
+    
+    # Create timestamped subdirectory within the specified parent directory
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    input_name = Path(args.input_video).stem
+    static_name = Path(args.static_image).stem
+    config_name = Path(args.config).stem
+    subdir_name = f"ipadapter_stream_test_{config_name}_{input_name}_{static_name}_{timestamp}"
+    
+    # Combine parent directory with generated subdirectory name
+    final_output_dir = Path(args.output_dir) / subdir_name
+    args.output_dir = str(final_output_dir)
+    print(f"main: Using output directory: {args.output_dir}")
+    
+    # Validate input files
+    if not Path(args.config).exists():
+        print(f"main: Error - Config file not found: {args.config}")
+        return 1
+    
+    if not Path(args.input_video).exists():
+        print(f"main: Error - Input video not found: {args.input_video}")
+        return 1
+    
+    if not Path(args.static_image).exists():
+        print(f"main: Error - Static image not found: {args.static_image}")
+        return 1
+    
+    print("IPAdapter Stream Test Demo")
+    print("=" * 50)
+    print(f"main: Config: {args.config}")
+    print(f"main: Input video: {args.input_video}")
+    print(f"main: Static image: {args.static_image}")
+    print(f"main: Output directory: {args.output_dir}")
+    print("=" * 50)
+    print("Test Description:")
+    print("- Input video frames → ControlNet control images (structural guidance)")
+    print("- Input video frames → IPAdapter style images (style/content guidance)")
+    print("- Static image → Base input to StreamDiffusion (repeated for each frame)")
+    print("- is_stream=True → High-throughput pipelined processing")
+    print("- Tests IPAdapter stream behavior fix")
+    print("=" * 50)
+    
+    try:
+        metrics = process_video_ipadapter_stream(
+            args.config, 
+            args.input_video, 
+            args.static_image, 
+            args.output_dir, 
+            engine_only=args.engine_only
+        )
+        if args.engine_only:
+            print("main: Engine-only mode completed successfully!")
+            return 0
+        print("main: IPAdapter stream test completed successfully!")
+        return 0
+    except Exception as e:
+        import traceback
+        print(f"main: Error during processing: {e}")
+        print(f"main: Traceback:\n{''.join(traceback.format_tb(e.__traceback__))}")
+        return 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -193,8 +193,8 @@ class IPAdapterModule(OrchestratorUser):
                     setattr(stream, 'scale', float(new_scale))
                 except Exception:
                     pass
-            def _update_style_image(style_image) -> None:
-                stream._param_updater.update_style_image(style_key, style_image, is_stream=False)
+            def _update_style_image(style_image, is_stream=False) -> None:
+                stream._param_updater.update_style_image(style_key, style_image, is_stream=is_stream)
             setattr(stream, 'update_scale', _update_scale)
             setattr(stream, 'update_style_image', _update_style_image)
         except Exception:

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional, Tuple, Any
+from enum import Enum
 import torch
 
 from streamdiffusion.hooks import EmbedsCtx, EmbeddingHook, StepCtx, UnetKwargsDelta, UnetHook
 import os
 from streamdiffusion.preprocessing.orchestrator_user import OrchestratorUser
+
+
+class IPAdapterType(Enum):
+    REGULAR = "regular"
+    PLUS = "plus"
+    FACEID = "faceid"
 
 
 @dataclass
@@ -22,8 +29,10 @@ class IPAdapterConfig:
     image_encoder_path: Optional[str] = None
     style_image: Optional[Any] = None
     scale: float = 1.0
-    # FaceID support
-    is_faceid: bool = False
+    weight_type: Optional[str] = None  # Weight type for per-layer scaling
+    enabled: bool = True  # Runtime enable/disable state
+
+    type: IPAdapterType = IPAdapterType.REGULAR
     insightface_model_name: Optional[str] = None
 
 
@@ -97,7 +106,7 @@ class IPAdapterModule(OrchestratorUser):
         - Registers IPAdapterEmbeddingPreprocessor with StreamParameterUpdater using style_image_key
         - Optionally processes provided style image to populate the embedding cache
         - Registers the embedding hook onto stream.embedding_hooks
-        - Sets the initial scale and mirrors it onto stream.ipadapter_scale
+        - Sets the initial scale on the IPAdapter instance
         """
         logger = __import__('logging').getLogger(__name__)
         style_key = self.config.style_image_key or "ipadapter_main"
@@ -133,7 +142,7 @@ class IPAdapterModule(OrchestratorUser):
             'device': stream.device,
             'dtype': stream.dtype,
         }
-        if bool(self.config.is_faceid) and self.config.insightface_model_name:
+        if self.config.type == IPAdapterType.FACEID and self.config.insightface_model_name:
             ip_kwargs['insightface_model_name'] = self.config.insightface_model_name
             print(
                 f"IPAdapterModule.install: Initializing FaceID IP-Adapter with InsightFace model: {self.config.insightface_model_name}"
@@ -143,11 +152,7 @@ class IPAdapterModule(OrchestratorUser):
 
         # Register embedding preprocessor for this style key 
         # Use FaceID preprocessor if applicable
-        try:
-            use_faceid_preproc = hasattr(ipadapter, 'is_faceid') and bool(getattr(ipadapter, 'is_faceid'))
-        except Exception:
-            use_faceid_preproc = False
-        if use_faceid_preproc:
+        if self.config.type == IPAdapterType.FACEID:
             try:
                 from streamdiffusion.preprocessing.processors.faceid_embedding import FaceIDEmbeddingPreprocessor
                 embedding_preprocessor = FaceIDEmbeddingPreprocessor(
@@ -175,28 +180,19 @@ class IPAdapterModule(OrchestratorUser):
                 logger.error(f"IPAdapterModule.install: Failed to process style image: {e}")
                 raise
 
-        # Set initial scale and mirror onto stream for TRT runtime vector if needed
+        # Set initial scale on the IPAdapter instance
         try:
             ipadapter.set_scale(float(self.config.scale))
-            setattr(stream, 'ipadapter_scale', float(self.config.scale))
         except Exception:
             pass
 
-        # Compatibility: expose expected attributes/methods used by StreamParameterUpdater
+        # Expose IPAdapter instance as single source of truth
         try:
             setattr(stream, 'ipadapter', ipadapter)
-            setattr(stream, 'scale', float(self.config.scale))
-            def _update_scale(new_scale: float) -> None:
-                ipadapter.set_scale(float(new_scale))
-                setattr(stream, 'ipadapter_scale', float(new_scale))
-                try:
-                    setattr(stream, 'scale', float(new_scale))
-                except Exception:
-                    pass
-            def _update_style_image(style_image, is_stream=False) -> None:
-                stream._param_updater.update_style_image(style_key, style_image, is_stream=is_stream)
-            setattr(stream, 'update_scale', _update_scale)
-            setattr(stream, 'update_style_image', _update_style_image)
+            # Extend IPAdapter with our custom attributes since diffusers IPAdapter doesn't expose current state
+            setattr(ipadapter, 'weight_type', self.config.weight_type)  # For build_layer_weights
+            setattr(ipadapter, 'scale', float(self.config.scale))       # Track current scale
+            setattr(ipadapter, 'enabled', bool(self.config.enabled))    # Track enabled state
         except Exception:
             pass
 
@@ -253,17 +249,22 @@ class IPAdapterModule(OrchestratorUser):
         - For TensorRT UNet engines compiled with IP-Adapter, pass a per-layer vector in extra kwargs
         - For PyTorch UNet with installed IP processors, modulate per-layer processor scale by time factor
         """
+        _last_enabled_state = None  # Track previous enabled state to avoid redundant updates
+        
         def _unet_hook(ctx: StepCtx) -> UnetKwargsDelta:
             # If no IP-Adapter installed, do nothing
             if not hasattr(stream, 'ipadapter') or stream.ipadapter is None:
                 return UnetKwargsDelta()
 
-            # Read base weight and weight type from stream
+            # Check if IPAdapter is enabled
+            enabled = getattr(stream.ipadapter, 'enabled', True)
+
+            # Read base weight and weight type from IPAdapter instance
             try:
-                base_weight = float(getattr(stream, 'ipadapter_scale', getattr(self, 'config', None).scale if hasattr(self, 'config') else 1.0))
+                base_weight = float(getattr(stream.ipadapter, 'scale', 1.0)) if enabled else 0.0
             except Exception:
-                base_weight = 1.0
-            weight_type = getattr(stream, 'ipadapter_weight_type', None)
+                base_weight = 0.0 if not enabled else 1.0
+            weight_type = getattr(stream.ipadapter, 'weight_type', None)
 
             # Determine total steps and current step index for time scheduling
             total_steps = None
@@ -306,8 +307,7 @@ class IPAdapterModule(OrchestratorUser):
                     except Exception:
                         weights_tensor = None
                     if weights_tensor is None:
-                        import torch as _torch
-                        weights_tensor = _torch.full((num_ip_layers,), float(base_weight), dtype=_torch.float32, device=stream.device)
+                        weights_tensor = torch.full((num_ip_layers,), float(base_weight), dtype=torch.float32, device=stream.device)
                     # Apply per-step time factor
                     try:
                         weights_tensor = weights_tensor * float(time_factor)
@@ -315,13 +315,19 @@ class IPAdapterModule(OrchestratorUser):
                         pass
                     return UnetKwargsDelta(extra_unet_kwargs={'ipadapter_scale': weights_tensor})
 
-            # PyTorch UNet path: modulate installed processor scales by time factor
+            # PyTorch UNet path: modulate installed processor scales by time factor and enabled state
             try:
-                if time_factor != 1.0 and hasattr(stream.pipe, 'unet') and hasattr(stream.pipe.unet, 'attn_processors'):
+                nonlocal _last_enabled_state
+                # Only process if we need to make changes (time scaling or state transition)
+                needs_update = (time_factor != 1.0 or enabled != _last_enabled_state)
+                if needs_update and hasattr(stream.pipe, 'unet') and hasattr(stream.pipe.unet, 'attn_processors'):
+                    _last_enabled_state = enabled
                     for proc in stream.pipe.unet.attn_processors.values():
                         if hasattr(proc, 'scale') and hasattr(proc, '_ip_layer_index'):
                             base_val = getattr(proc, '_base_scale', proc.scale)
-                            proc.scale = float(base_val) * float(time_factor)
+                            # Apply both enabled state and time factor
+                            final_scale = float(base_val) * float(time_factor) if enabled else 0.0
+                            proc.scale = final_scale
             except Exception:
                 pass
 

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -104,9 +104,6 @@ class StreamDiffusion:
 
         # Initialize parameter updater
         self._param_updater = StreamParameterUpdater(self, normalize_prompt_weights, normalize_seed_weights)
-        # Default IP-Adapter runtime weight mode (None = uniform). Can be set to strings like
-        # "ease in", "ease out", "ease in-out", "reverse in-out", "style transfer precise", "composition precise".
-        self.ipadapter_weight_type = None
 
         # Hook containers (step 1: introduced but initially no-op)
         self.embedding_hooks: List[EmbeddingHook] = []

--- a/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
@@ -43,12 +43,6 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
         super().__init__(ipadapter=ipadapter, **kwargs)
         self.faceid_v2_weight = float(faceid_v2_weight)
 
-        # Verify this is a FaceID-capable IP-Adapter
-        if not hasattr(ipadapter, "is_faceid") or not bool(ipadapter.is_faceid):
-            raise ValueError(
-                "FaceIDEmbeddingPreprocessor: ipadapter must be a FaceID-capable IPAdapter with is_faceid=True"
-            )
-
         if not hasattr(ipadapter, "insightface_model") or ipadapter.insightface_model is None:
             raise ValueError(
                 "FaceIDEmbeddingPreprocessor: ipadapter must have an initialized InsightFace model"

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1773,11 +1773,11 @@ class StreamDiffusionWrapper:
             logger.debug("update_control_image: Skipping ControlNet update in skip diffusion mode")
 
 
-    def update_style_image(self, image: Union[str, Image.Image, torch.Tensor]) -> None:
+    def update_style_image(self, image: Union[str, Image.Image, torch.Tensor], is_stream: bool = False) -> None:
         """Update IPAdapter style image"""
         if not self.use_ipadapter:
             raise RuntimeError("update_style_image: IPAdapter support not enabled. Set use_ipadapter=True in constructor.")
-        self.stream.update_style_image(image)
+        self.stream.update_style_image(image, is_stream=is_stream)
         
 
     def clear_caches(self) -> None:

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1219,7 +1219,7 @@ class StreamDiffusionWrapper:
                     # scale omitted from engine naming; runtime will pass ipadapter_scale vector
                     ipadapter_tokens = cfg0.get('num_image_tokens', 4)
                     # Determine FaceID type from config for engine naming
-                    is_faceid = (cfg0.get('type') == 'faceid' or bool(cfg0.get('is_faceid', False)))
+                    is_faceid = (cfg0['type'] == 'faceid')
                 # Generate engine paths using EngineManager
                 unet_path = engine_manager.get_engine_path(
                     EngineType.UNET,
@@ -1307,7 +1307,7 @@ class StreamDiffusionWrapper:
                 # If using TensorRT with IP-Adapter, ensure processors and weights are installed BEFORE export
                 if use_ipadapter_trt and has_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module'):
                     try:
-                        from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig
+                        from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
                         cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
                         ip_cfg = IPAdapterConfig(
                             style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
@@ -1316,7 +1316,7 @@ class StreamDiffusionWrapper:
                             image_encoder_path=cfg['image_encoder_path'],
                             style_image=cfg.get('style_image'),
                             scale=cfg.get('scale', 1.0),
-                            is_faceid=(cfg.get('type') == 'faceid' or bool(cfg.get('is_faceid', False))),
+                            type=IPAdapterType(cfg.get('type', "regular")),
                             insightface_model_name=cfg.get('insightface_model_name'),
                         )
                         ip_module_for_export = IPAdapterModule(ip_cfg)
@@ -1678,9 +1678,13 @@ class StreamDiffusionWrapper:
 
         if use_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module'):
             try:
-                from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig
+                from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
                 # Use first config if list provided
                 cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
+                
+                # Get adapter type from config  
+                ipadapter_type = IPAdapterType(cfg['type'])
+                
                 ip_cfg = IPAdapterConfig(
                     style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
                     num_image_tokens=cfg.get('num_image_tokens', 4),
@@ -1688,7 +1692,7 @@ class StreamDiffusionWrapper:
                     image_encoder_path=cfg['image_encoder_path'],
                     style_image=cfg.get('style_image'),
                     scale=cfg.get('scale', 1.0),
-                    is_faceid=(cfg.get('type') == 'faceid' or bool(cfg.get('is_faceid', False))),
+                    type=ipadapter_type,
                     insightface_model_name=cfg.get('insightface_model_name'),
                 )
                 ip_module = IPAdapterModule(ip_cfg)
@@ -1773,11 +1777,17 @@ class StreamDiffusionWrapper:
             logger.debug("update_control_image: Skipping ControlNet update in skip diffusion mode")
 
 
-    def update_style_image(self, image: Union[str, Image.Image, torch.Tensor], is_stream: bool = False) -> None:
+    def update_style_image(self, image: Union[str, Image.Image, torch.Tensor], is_stream: bool = False, style_key = "ipadapter_main") -> None:
         """Update IPAdapter style image"""
         if not self.use_ipadapter:
             raise RuntimeError("update_style_image: IPAdapter support not enabled. Set use_ipadapter=True in constructor.")
-        self.stream.update_style_image(image, is_stream=is_stream)
+        
+        if not self.skip_diffusion:
+            self.stream._param_updater.update_style_image(style_key, image, is_stream=is_stream)
+        else:
+            logger.debug("update_style_image: Skipping IPAdapter update in skip diffusion mode")
+        
+        
         
 
     def clear_caches(self) -> None:


### PR DESCRIPTION
# IPAdapter Architecture Refactor & Runtime Control

## PR #130: Ryan/fix/ipadapter/01 is stream
This PR follows through with the is_stream behavior of IPAdapter style image updates. This takes advantage of the available pipelining for IPAdapter embedding generation, and allows users to use a video as a style reference for IPAdapters as opposed to just a static image. 

- Live Style Transfer: Apply video frames as style references in real-time
- Art Applications: Users paint/draw style images that immediately affect generation
- Multi-Modal Pipelines: Combine ControlNet structure + IPAdapter style with video input

Cursory testing shows that pipelining IPAdapter embeddings results in a ~27% performance improvement in this scenario.

## PR #132: ryan/fix/ipadapter/02 refactor: centralize IPAdapter state management on instance
Refactor IPAdapter architecture to use centralized state management.

**Changes:**
- IPAdapter instance now stores its own scale/weight_type state instead of scattered stream attributes
- StreamParameterUpdater reads from IPAdapter instance as single source of truth
- Demo files updated to use unified get_stream_state() API
- Removed legacy ipadapter_weight_type from pipeline class
- Fixed wrapper.update_style_image() to properly delegate to parameter updater

**Benefits:**
- Single source of truth for IPAdapter state
- Better encapsulation and cleaner architecture
- Reduced complexity and improved maintainability

## PR #133: ryan/fix/ipadapter/03 runtime ipdadapter enable disable
Adds ability to enable/disable IPAdapter at runtime without pipeline restart.

Changes:
- Frontend: Toggle switch in IPAdapter config panel
- Backend: /api/ipadapter/update-enabled endpoint  
- Core: enabled field in IPAdapterConfig, UNet hook respects enabled state
- Performance: Fixed time_factor optimization (only update when time_factor != 1.0 OR enabled=False)

Usage: Toggle IPAdapter on/off in real-time while preserving scale/weight settings.
Fixes: Runtime control issue where IPAdapter required pipeline restart to disable.

## PR #134: ryan/fix/ipadapter/04 refactor: replace is_faceid boolean with IPAdapterType enum
Replace boolean `is_faceid` flag with proper `IPAdapterType` enum for better type safety and extensibility.

**Changes:**
- New `IPAdapterType` enum with REGULAR/PLUS/FACEID values
- `IPAdapterConfig.adapter_type` replaces `is_faceid` boolean
- Updated config handling across all modules
- Removed old config format support

**Breaking:** YAML configs must use `type: "faceid"` instead of `is_faceid: true`. The interface is otherwise unchanged.