### PR TITLE
ryan/fix/ipadapter/04 refactor: replace is_faceid boolean with IPAdapterType enum

### DIFF
--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional, Tuple, Any
+from enum import Enum
 import torch
 
 from streamdiffusion.hooks import EmbedsCtx, EmbeddingHook, StepCtx, UnetKwargsDelta, UnetHook
 import os
 from streamdiffusion.preprocessing.orchestrator_user import OrchestratorUser
+
+
+class IPAdapterType(Enum):
+    REGULAR = "regular"
+    PLUS = "plus"
+    FACEID = "faceid"
 
 
 @dataclass
@@ -24,8 +31,8 @@ class IPAdapterConfig:
     scale: float = 1.0
     weight_type: Optional[str] = None  # Weight type for per-layer scaling
     enabled: bool = True  # Runtime enable/disable state
-    # FaceID support
-    is_faceid: bool = False
+
+    adapter_type: IPAdapterType = IPAdapterType.REGULAR
     insightface_model_name: Optional[str] = None
 
 
@@ -135,7 +142,7 @@ class IPAdapterModule(OrchestratorUser):
             'device': stream.device,
             'dtype': stream.dtype,
         }
-        if bool(self.config.is_faceid) and self.config.insightface_model_name:
+        if self.config.adapter_type == IPAdapterType.FACEID and self.config.insightface_model_name:
             ip_kwargs['insightface_model_name'] = self.config.insightface_model_name
             print(
                 f"IPAdapterModule.install: Initializing FaceID IP-Adapter with InsightFace model: {self.config.insightface_model_name}"
@@ -145,11 +152,7 @@ class IPAdapterModule(OrchestratorUser):
 
         # Register embedding preprocessor for this style key 
         # Use FaceID preprocessor if applicable
-        try:
-            use_faceid_preproc = hasattr(ipadapter, 'is_faceid') and bool(getattr(ipadapter, 'is_faceid'))
-        except Exception:
-            use_faceid_preproc = False
-        if use_faceid_preproc:
+        if self.config.adapter_type == IPAdapterType.FACEID:
             try:
                 from streamdiffusion.preprocessing.processors.faceid_embedding import FaceIDEmbeddingPreprocessor
                 embedding_preprocessor = FaceIDEmbeddingPreprocessor(

--- a/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
@@ -43,12 +43,6 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
         super().__init__(ipadapter=ipadapter, **kwargs)
         self.faceid_v2_weight = float(faceid_v2_weight)
 
-        # Verify this is a FaceID-capable IP-Adapter
-        if not hasattr(ipadapter, "is_faceid") or not bool(ipadapter.is_faceid):
-            raise ValueError(
-                "FaceIDEmbeddingPreprocessor: ipadapter must be a FaceID-capable IPAdapter with is_faceid=True"
-            )
-
         if not hasattr(ipadapter, "insightface_model") or ipadapter.insightface_model is None:
             raise ValueError(
                 "FaceIDEmbeddingPreprocessor: ipadapter must have an initialized InsightFace model"

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -1327,7 +1327,7 @@ class StreamParameterUpdater(OrchestratorUser):
                 config.update({
                     'style_image_key': module_config.style_image_key,
                     'num_image_tokens': module_config.num_image_tokens,
-                    'is_faceid': module_config.is_faceid,
+                    'type': module_config.adapter_type.value,
                 })
             
             # Check if style image is set

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1219,7 +1219,7 @@ class StreamDiffusionWrapper:
                     # scale omitted from engine naming; runtime will pass ipadapter_scale vector
                     ipadapter_tokens = cfg0.get('num_image_tokens', 4)
                     # Determine FaceID type from config for engine naming
-                    is_faceid = (cfg0.get('type') == 'faceid' or bool(cfg0.get('is_faceid', False)))
+                    is_faceid = (cfg0['type'] == 'faceid')
                 # Generate engine paths using EngineManager
                 unet_path = engine_manager.get_engine_path(
                     EngineType.UNET,
@@ -1316,7 +1316,7 @@ class StreamDiffusionWrapper:
                             image_encoder_path=cfg['image_encoder_path'],
                             style_image=cfg.get('style_image'),
                             scale=cfg.get('scale', 1.0),
-                            is_faceid=(cfg.get('type') == 'faceid' or bool(cfg.get('is_faceid', False))),
+                            adapter_type=IPAdapterType(cfg['type']),
                             insightface_model_name=cfg.get('insightface_model_name'),
                         )
                         ip_module_for_export = IPAdapterModule(ip_cfg)
@@ -1678,9 +1678,13 @@ class StreamDiffusionWrapper:
 
         if use_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module'):
             try:
-                from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig
+                from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
                 # Use first config if list provided
                 cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
+                
+                # Get adapter type from config  
+                adapter_type = IPAdapterType(cfg['type'])
+                
                 ip_cfg = IPAdapterConfig(
                     style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
                     num_image_tokens=cfg.get('num_image_tokens', 4),
@@ -1688,7 +1692,7 @@ class StreamDiffusionWrapper:
                     image_encoder_path=cfg['image_encoder_path'],
                     style_image=cfg.get('style_image'),
                     scale=cfg.get('scale', 1.0),
-                    is_faceid=(cfg.get('type') == 'faceid' or bool(cfg.get('is_faceid', False))),
+                    adapter_type=adapter_type,
                     insightface_model_name=cfg.get('insightface_model_name'),
                 )
                 ip_module = IPAdapterModule(ip_cfg)


### PR DESCRIPTION
Replace boolean `is_faceid` flag with proper `IPAdapterType` enum for better type safety and extensibility.

**Changes:**
- New `IPAdapterType` enum with REGULAR/PLUS/FACEID values
- `IPAdapterConfig.adapter_type` replaces `is_faceid` boolean
- Updated config handling across all modules
- Removed old config format support

**Breaking:** YAML configs must use `type: "faceid"` instead of `is_faceid: true`. The interface is otherwise unchanged. 