### PR TITLE
refactor: pass processor params as constructor kwargs

### DIFF
--- a/src/streamdiffusion/modules/controlnet_module.py
+++ b/src/streamdiffusion/modules/controlnet_module.py
@@ -98,20 +98,9 @@ class ControlNetModule(OrchestratorUser):
         preproc = None
         if cfg.preprocessor:
             from streamdiffusion.preprocessing.processors import get_preprocessor
-            preproc = get_preprocessor(cfg.preprocessor, pipeline_ref=self._stream)
-            # Apply provided parameters to the preprocessor instance
-            if cfg.preprocessor_params:
-                params = cfg.preprocessor_params or {}
-                # If the preprocessor exposes a 'params' dict, update it
-                if hasattr(preproc, 'params') and isinstance(getattr(preproc, 'params'), dict):
-                    preproc.params.update(params)
-                # Also set attributes directly when they exist
-                for name, value in params.items():
-                    try:
-                        if hasattr(preproc, name):
-                            setattr(preproc, name, value)
-                    except Exception:
-                        pass
+            # Pass all preprocessor params as constructor kwargs
+            preprocessor_params = cfg.preprocessor_params or {}
+            preproc = get_preprocessor(cfg.preprocessor, pipeline_ref=self._stream, **preprocessor_params)
 
 
             # Align preprocessor target size with stream resolution once (avoid double-resize later)

--- a/src/streamdiffusion/modules/image_processing_module.py
+++ b/src/streamdiffusion/modules/image_processing_module.py
@@ -42,20 +42,9 @@ class ImageProcessingModule(OrchestratorUser):
         # Check if processor is enabled (default to True, same as ControlNet)
         enabled = proc_config.get('enabled', True)
         
-        # Create processor using existing registry (same as ControlNet)
-        processor = get_preprocessor(processor_type, pipeline_ref=getattr(self, '_stream', None))
-        
-        # Apply parameters (same pattern as ControlNet)
+        # Pass all processor params as constructor kwargs
         processor_params = proc_config.get('params', {})
-        if processor_params:
-            if hasattr(processor, 'params') and isinstance(getattr(processor, 'params'), dict):
-                processor.params.update(processor_params)
-            for name, value in processor_params.items():
-                try:
-                    if hasattr(processor, name):
-                        setattr(processor, name, value)
-                except Exception:
-                    pass
+        processor = get_preprocessor(processor_type, pipeline_ref=getattr(self, '_stream', None), **processor_params)
         
         # Set order for sequential execution
         order = proc_config.get('order', len(self.processors))

--- a/src/streamdiffusion/modules/latent_processing_module.py
+++ b/src/streamdiffusion/modules/latent_processing_module.py
@@ -41,20 +41,9 @@ class LatentProcessingModule(OrchestratorUser):
         # Check if processor is enabled (default to True, same as ControlNet)
         enabled = proc_config.get('enabled', True)
         
-        # Create processor using existing registry (same as ControlNet)
-        processor = get_preprocessor(processor_type, pipeline_ref=self._stream)
-        
-        # Apply parameters (same pattern as ControlNet)
+        # Pass all processor params as constructor kwargs
         processor_params = proc_config.get('params', {})
-        if processor_params:
-            if hasattr(processor, 'params') and isinstance(getattr(processor, 'params'), dict):
-                processor.params.update(processor_params)
-            for name, value in processor_params.items():
-                try:
-                    if hasattr(processor, name):
-                        setattr(processor, name, value)
-                except Exception:
-                    pass
+        processor = get_preprocessor(processor_type, pipeline_ref=self._stream, **processor_params)
         
         # Set order for sequential execution
         order = proc_config.get('order', len(self.processors))


### PR DESCRIPTION
Replaces post-construction setattr loops with direct constructor parameter passing.
- Modified get_preprocessor() to accept **constructor_kwargs
- Updated ControlNet, Image, and Latent processing modules
- Cleaner, more reliable parameter handling for all processors