### PR TITLE
fix: add __init__.py to make utils.reporting importable

### DIFF
--- a/src/streamdiffusion/utils/__init__.py
+++ b/src/streamdiffusion/utils/__init__.py
@@ -1,0 +1,5 @@
+from .reporting import report_error
+
+__all__ = [
+    "report_error",
+]


### PR DESCRIPTION
Found when trying to use faceid_embedding preprocessor

Fixes ModuleNotFoundError when importing from streamdiffusion.utils.reporting